### PR TITLE
batsat: Make `log` visible at the crate-level, regardless of feature

### DIFF
--- a/src/batsat/src/lib.rs
+++ b/src/batsat/src/lib.rs
@@ -41,7 +41,7 @@ pub(crate) mod log {
 
 #[cfg(feature = "logging")]
 #[macro_use]
-pub extern crate log;
+pub(crate) extern crate log;
 
 //======== PUBLIC INTERFACE ============
 


### PR DESCRIPTION
Previously, if the `logging` feature was present, the `log` dependency was re-exported publicly, whereas without the feature it wasn't.