### PR TITLE
Add more flexible model API

### DIFF
--- a/src/batsat/src/core.rs
+++ b/src/batsat/src/core.rs
@@ -292,10 +292,18 @@ impl<Cb: Callbacks> SolverInterface for Solver<Cb> {
         self.tmp_c_add_cl.clear();
     }
 
-    fn solve_limited_th<Th: Theory>(&mut self, th: &mut Th, assumps: &[Lit]) -> lbool {
+    fn raw_solve_limited_th<Th: Theory>(&mut self, th: &mut Th, assumps: &[Lit]) -> lbool {
         self.v.assumptions.clear();
         self.v.assumptions.extend_from_slice(assumps);
         self.solve_internal(th)
+    }
+
+    fn pop_model<Th: Theory>(&mut self, th: &mut Th) {
+        self.cancel_until(th, 0)
+    }
+
+    fn raw_value_lit(&self, l: Lit) -> lbool {
+        self.v.value_lit(l)
     }
 
     #[inline(always)]
@@ -791,12 +799,8 @@ impl<Cb: Callbacks> Solver<Cb> {
             self.v.ok = false;
         }
 
-        self.cancel_until(th, 0);
         debug!("res: {:?}", status);
-        trace!(
-            "proved at lvl 0: {:?}",
-            self.v.vars.iter_trail().collect::<Vec<_>>()
-        );
+        trace!("proved at lvl 0: {:?}", self.v.vars.proved_at_lvl_0());
         status
     }
 

--- a/src/batsat/src/core.rs
+++ b/src/batsat/src/core.rs
@@ -292,7 +292,11 @@ impl<Cb: Callbacks> SolverInterface for Solver<Cb> {
         self.tmp_c_add_cl.clear();
     }
 
-    fn raw_solve_limited_th<Th: Theory>(&mut self, th: &mut Th, assumps: &[Lit]) -> lbool {
+    fn solve_limited_preserving_trail_th<Th: Theory>(
+        &mut self,
+        th: &mut Th,
+        assumps: &[Lit],
+    ) -> lbool {
         self.v.assumptions.clear();
         self.v.assumptions.extend_from_slice(assumps);
         self.solve_internal(th)

--- a/src/batsat/src/interface.rs
+++ b/src/batsat/src/interface.rs
@@ -66,7 +66,7 @@ pub trait SolverInterface {
     ///
     /// - `th` is the theory.
     fn solve_limited_th<Th: Theory>(&mut self, th: &mut Th, assumps: &[Lit]) -> lbool {
-        let res = self.raw_solve_limited_th(th, assumps);
+        let res = self.solve_limited_preserving_trail_th(th, assumps);
         self.pop_model(th);
         res
     }
@@ -77,10 +77,14 @@ pub trait SolverInterface {
     /// to `self` or `th`
     ///
     /// - `th` is the theory.
-    fn raw_solve_limited_th<Th: Theory>(&mut self, th: &mut Th, assumps: &[Lit]) -> lbool;
+    fn solve_limited_preserving_trail_th<Th: Theory>(
+        &mut self,
+        th: &mut Th,
+        assumps: &[Lit],
+    ) -> lbool;
 
     /// Restore the state of `self` and `th` after calling
-    /// [`raw_solve_limited_th`](Self::raw_solve_limited_th)
+    /// [`raw_solve_limited_th`](Self::solve_limited_preserving_trail_th)
     ///
     /// This method is idempotent
     fn pop_model<Th: Theory>(&mut self, th: &mut Th);
@@ -88,7 +92,7 @@ pub trait SolverInterface {
     /// Value of this literal if it's assigned or `UNDEF` otherwise
     ///
     /// Returns the model value if it is called between
-    /// [`raw_solve_limited_th`](Self::raw_solve_limited_th) and [`pop_model`](Self::pop_model)
+    /// [`raw_solve_limited_th`](Self::solve_limited_preserving_trail_th) and [`pop_model`](Self::pop_model)
     fn raw_value_lit(&self, l: Lit) -> lbool;
 
     /// Solve using the given theory and return a [`SolveResult`]
@@ -97,7 +101,7 @@ pub trait SolverInterface {
         th: &'a mut Th,
         assumps: &[Lit],
     ) -> SolveResult<'a, Self, Th> {
-        let res = self.raw_solve_limited_th(th, assumps);
+        let res = self.solve_limited_preserving_trail_th(th, assumps);
         if res == lbool::FALSE {
             self.pop_model(th);
             return SolveResult::Unsat(self.unsat_core());


### PR DESCRIPTION
I was working on a [toy SMT solver](https://github.com/dewert99/bat_egg_smt) (`QF_UF` only) and I got stuck implementing `get_value` and `get_model` since `Solver::solve_limited_th` reverts the state of the `Theory` to level 0 by calling (`Theory::pop_levels`) before returning. I though it would be helpful to allow these break this reverting out of `Solver::solve_limited_th`. Does this seem reasonable? I'm open to suggestions about naming.